### PR TITLE
Add pygraphviz test workflow

### DIFF
--- a/.github/workflows/pygraphviz-test.yml
+++ b/.github/workflows/pygraphviz-test.yml
@@ -26,6 +26,11 @@ jobs:
         if: matrix.method == 'conda'
         run: |
           conda install -y graphviz pygraphviz networkx ipython
+      - name: Install system packages for pip
+        if: matrix.method == 'pip'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz libgraphviz-dev
       - name: Install dependencies with pip
         if: matrix.method == 'pip'
         run: |

--- a/.github/workflows/pygraphviz-test.yml
+++ b/.github/workflows/pygraphviz-test.yml
@@ -2,6 +2,7 @@ name: pygraphviz-test
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/pygraphviz-test.yml
+++ b/.github/workflows/pygraphviz-test.yml
@@ -1,0 +1,34 @@
+name: pygraphviz-test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        method: [conda, pip]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Setup conda
+        if: matrix.method == 'conda'
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          python-version: 3.11
+      - name: Install dependencies with conda
+        if: matrix.method == 'conda'
+        run: |
+          conda install -y graphviz pygraphviz networkx ipython
+      - name: Install dependencies with pip
+        if: matrix.method == 'pip'
+        run: |
+          python -m pip install --upgrade pip
+          pip install graphviz pygraphviz networkx ipython
+      - name: Run pygraphviz test
+        run: python run_pygraphviz_test.py

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # gha-sandbox
+
 debug GHA environment quirks
+
+This repository contains a workflow that exercises `pygraphviz` on
+GitHub Actions using both conda and pip installs. Run the `pygraphviz-test`
+workflow manually to check whether the shared libraries required by
+`pygraphviz` are available on the Ubuntu runner.

--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@ debug GHA environment quirks
 This repository contains a workflow that exercises `pygraphviz` on
 GitHub Actions using both conda and pip installs. The `pygraphviz-test`
 workflow runs automatically on pull requests and can also be triggered
-manually. Use it to verify that the shared libraries required by
-`pygraphviz` are available on the Ubuntu runner.
+manually. One job installs `graphviz` and `pygraphviz` via conda.
+The other installs system packages with `apt` and then installs the
+Python packages via `pip`. Use this workflow to verify that the shared
+libraries required by `pygraphviz` are available on the Ubuntu runner.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 debug GHA environment quirks
 
 This repository contains a workflow that exercises `pygraphviz` on
-GitHub Actions using both conda and pip installs. Run the `pygraphviz-test`
-workflow manually to check whether the shared libraries required by
+GitHub Actions using both conda and pip installs. The `pygraphviz-test`
+workflow runs automatically on pull requests and can also be triggered
+manually. Use it to verify that the shared libraries required by
 `pygraphviz` are available on the Ubuntu runner.

--- a/run_pygraphviz_test.py
+++ b/run_pygraphviz_test.py
@@ -1,5 +1,6 @@
 import networkx as nx
 from graphviz import Source
+from IPython.display import display
 
 # Minimal example to trigger pygraphviz usage via networkx
 
@@ -10,8 +11,10 @@ def to_graphviz():
 
 if __name__ == "__main__":
     try:
-        # Print the dot source to exercise pygraphviz
-        print(to_graphviz().source)
+        gviz = to_graphviz()
+        print(gviz.source)
+        # Emulate notebook usage
+        display(gviz)
     except Exception as e:
         print("Encountered error:", e)
         raise

--- a/run_pygraphviz_test.py
+++ b/run_pygraphviz_test.py
@@ -1,0 +1,17 @@
+import networkx as nx
+from graphviz import Source
+
+# Minimal example to trigger pygraphviz usage via networkx
+
+def to_graphviz():
+    g = nx.DiGraph()
+    g.add_edge("a", "b")
+    return Source(nx.nx_agraph.to_agraph(g).string())
+
+if __name__ == "__main__":
+    try:
+        # Print the dot source to exercise pygraphviz
+        print(to_graphviz().source)
+    except Exception as e:
+        print("Encountered error:", e)
+        raise


### PR DESCRIPTION
## Summary
- add workflow matrix to compare `conda` vs `pip` installs of graphviz/pygraphviz
- add small script that exercises `networkx` with `pygraphviz`
- document workflow in README

## Testing
- `python run_pygraphviz_test.py` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_68574d7e13448332ba806f1ca156f8f1