### PR TITLE
Update GHA triggers with concurrency

### DIFF
--- a/.github/workflows/check-vs-version.yml
+++ b/.github/workflows/check-vs-version.yml
@@ -1,6 +1,15 @@
 name: Check Visual Studio Version
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - .github/workflows/check-vs-version.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   check_vs_version:

--- a/.github/workflows/debug_pypath.yml
+++ b/.github/workflows/debug_pypath.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - .github/workflows/debug_pypath.yml
 
 # Add concurrency control
 concurrency:

--- a/.github/workflows/debug_runners.yml
+++ b/.github/workflows/debug_runners.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - .github/workflows/debug_runners.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   debug:
     strategy:

--- a/.github/workflows/debug_windows_2025.yml
+++ b/.github/workflows/debug_windows_2025.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - .github/workflows/debug_windows_2025.yml
   workflow_dispatch:
 
 # Add concurrency control


### PR DESCRIPTION
## Summary
- restrict each workflow so PR jobs run only when that workflow file changes
- add concurrency groups to avoid duplicate runs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6857867a58a48332805162cd772dc4b4